### PR TITLE
STOMP 구독 시 인가 로직 추가

### DIFF
--- a/backend/nextdoor/build.gradle
+++ b/backend/nextdoor/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.security:spring-security-messaging:6.5.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
@@ -42,7 +42,7 @@ public class WebSocketSecurityConfig {
         }
         PathContainer pathContainer = PathContainer.parsePath(destination);
         if (!pattern.matches(pathContainer)) {
-            return new AuthorizationDecision(false);
+            return new AuthorizationDecision(true);
         }
         String destinationUuid = pattern.matchAndExtract(pathContainer).getUriVariables().get("uuid");
         String token = object.getMessage().getHeaders().get("authorization", String.class);

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
@@ -23,9 +23,8 @@ import java.util.function.Supplier;
 @EnableWebSocketSecurity
 public class WebSocketSecurityConfig {
 
-    private final PathPattern pattern = new PathPatternParser().parse(
-            "/topic/rental-reservation/{uuid}/**"
-    );
+    private final PathPattern pattern = new PathPatternParser()
+            .parse("/topic/rental-reservation/{uuid}/**");
     private final JwtProvider jwtProvider;
 
     @Bean

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebSocketSecurityConfig.java
@@ -1,0 +1,54 @@
+package com.nextdoor.nextdoor.config;
+
+import com.nextdoor.nextdoor.domain.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.PathContainer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.messaging.access.intercept.MessageAuthorizationContext;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketSecurity
+public class WebSocketSecurityConfig {
+
+    private final PathPattern pattern = new PathPatternParser().parse(
+            "/topic/rental-reservation/{uuid}/**"
+    );
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public AuthorizationManager<Message<?>> messageAuthorizationManager(MessageMatcherDelegatingAuthorizationManager.Builder builder) {
+        return builder
+                .simpTypeMatchers(SimpMessageType.SUBSCRIBE).access(this::checkDestination)
+                .build();
+    }
+
+    private AuthorizationDecision checkDestination(Supplier<Authentication> authentication, MessageAuthorizationContext<?> object) {
+        String destination = object.getMessage().getHeaders().get("destination", String.class);
+        if (destination == null) {
+            return new AuthorizationDecision(false);
+        }
+        PathContainer pathContainer = PathContainer.parsePath(destination);
+        if (!pattern.matches(pathContainer)) {
+            return new AuthorizationDecision(false);
+        }
+        String destinationUuid = pattern.matchAndExtract(pathContainer).getUriVariables().get("uuid");
+        String token = object.getMessage().getHeaders().get("authorization", String.class);
+        if (!destinationUuid.equals(jwtProvider.validateAndGetUuid(token))) {
+            return new AuthorizationDecision(false);
+        }
+        return new AuthorizationDecision(true);
+    }
+}

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/jwt/JwtProvider.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/jwt/JwtProvider.java
@@ -25,6 +25,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .signWith(SECRET_KEY)
                 .subject(userPrincipal.getName())
+                .claim("uuid", userPrincipal.getUuid())
                 .issuer(ISSUER)
                 .issuedAt(new Date())
                 .expiration(expiryDate)
@@ -38,6 +39,16 @@ public class JwtProvider {
                 .parseSignedClaims(token)
                 .getPayload()
                 .getSubject();
+    }
+
+    public String validateAndGetUuid(String token) {
+        return Jwts.parser()
+                .verifyWith((SecretKey) SECRET_KEY)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("uuid")
+                .toString();
     }
 }
 

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/model/CustomOAuth2User.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/model/CustomOAuth2User.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -11,10 +12,13 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class CustomOAuth2User implements OAuth2User {
 
 	private String id;
+
+	@Getter
+	private String uuid;
 	private Collection<? extends GrantedAuthority> authorities;
 	private Map<String, Object> attributes;
 
-	public CustomOAuth2User(String id, Map<String, Object> attributes) {
+	public CustomOAuth2User(String id, String uuid, Map<String, Object> attributes) {
 		this.id = id;
 		this.attributes = attributes;
 		this.authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/oauth2/CustomOAuth2UserService.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/oauth2/CustomOAuth2UserService.java
@@ -64,9 +64,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             return newMember;
         });
-
-        return new CustomOAuth2User(member.getId().toString(), oAuth2User.getAttributes());
-
+        return new CustomOAuth2User(member.getId().toString(), member.getUuid(), oAuth2User.getAttributes());
     }
 
     @EventListener

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/chat/config/ChatWebSocketConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/chat/config/ChatWebSocketConfig.java
@@ -13,6 +13,11 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocketMessageBroker
 public class ChatWebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final String[] allowedOriginPatterns = {
+            "http://k12e205.p.ssafy.io",
+            "http://localhost:3000"
+    };
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
 //        registry.addEndpoint("/ws-chat")
@@ -20,12 +25,8 @@ public class ChatWebSocketConfig implements WebSocketMessageBrokerConfigurer {
 //                        "http://k12e205.p.ssafy.io",
 //                        "http://localhost:3000"
 //                );
-        registry
-                .addEndpoint("/ws-chat")                   // 클라이언트가 연결할 엔드포인트
-                .setAllowedOriginPatterns(
-                        "http://k12e205.p.ssafy.io",
-                        "http://localhost:3000"
-                )
+        registry.addEndpoint("/ws-chat")                   // 클라이언트가 연결할 엔드포인트
+                .setAllowedOriginPatterns(allowedOriginPatterns)
                 .withSockJS();             // SockJS fallback 지원
 
     }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/rentalreservation/infrastructure/config/WebSocketConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/rentalreservation/infrastructure/config/WebSocketConfig.java
@@ -12,6 +12,11 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final String[] allowedOriginPatterns = {
+            "http://k12e205.p.ssafy.io",
+            "http://localhost:3000"
+    };
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic").setHeartbeatValue(new long[] { 10_000, 10_000 })
@@ -22,16 +27,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-rental")
-                .setAllowedOriginPatterns(
-                        "http://k12e205.p.ssafy.io",
-                        "http://localhost:3000"
-                );
-
+                .setAllowedOriginPatterns(allowedOriginPatterns);
         registry.addEndpoint("/ws-rental")
-                .setAllowedOriginPatterns(
-                        "http://k12e205.p.ssafy.io",
-                        "http://localhost:3000"
-                )
+                .setAllowedOriginPatterns(allowedOriginPatterns)
                 .withSockJS();
     }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #19 

## 🚩 Summary
- Spring Security Messaging 의존성을 추가했습니다.
- 커스텀 OAuth2 사용자 클래스 및 JWT에 UUID를 추가했습니다.
- STOMP 구독 시 경로 인가 로직을 추가했습니다.

## 🛠️ Technical Concerns
- STOMP 구독 시 경로 인가 로직 추가
  1. STOMP SUBSCRIBE 메시지를 받았을 때 메시지의 destination 헤더 값과 authorization 헤더 값(JWT)을 확인합니다.
  2. 후자의 UUID 값이 변경되었으면 JWT가 위조된 것으로 처리합니다.
  3. 전자와 후자의 UUID가 다르면 권한이 없는 것으로 처리합니다.
  4. 둘 다 아닌 경우 정상적으로 구독할 수 있습니다.

  위 흐름으로 사용자는 자신의 UUID를 식별자로 갖는 경로만 구독할 수 있습니다.

## 🙂 To Reviewer
- 클래스별 역할이 적절히 분리되어 있는지 검토 바랍니다.

## 📋 To Do