### PR TITLE
Fix: 좋아요 카운트 Race Condition으로 인한 누락 문제 해결

### DIFF
--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/domain/PostLikeCount.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/domain/PostLikeCount.java
@@ -24,12 +24,4 @@ public class PostLikeCount {
         this.postId = postId;
         this.likeCount = likeCount;
     }
-
-    public void increaseLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decreaseLikeCount() {
-        this.likeCount--;
-    }
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/repository/PostLikeCountRepository.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/repository/PostLikeCountRepository.java
@@ -1,10 +1,20 @@
 package com.nextdoor.nextdoor.domain.post.repository;
 
 import com.nextdoor.nextdoor.domain.post.domain.PostLikeCount;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostLikeCountRepository extends JpaRepository<PostLikeCount, Long> {
-    // The primary key of PostLikeCount is postId, so we can use findById to find by postId
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PostLikeCount plc SET plc.likeCount = plc.likeCount + 1 WHERE plc.postId = :postId")
+    int incrementLikeCount(@Param("postId") Long postId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PostLikeCount plc SET plc.likeCount = plc.likeCount - 1 WHERE plc.postId = :postId")
+    int decrementLikeCount(@Param("postId") Long postId);
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/service/PostServiceImpl.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/post/service/PostServiceImpl.java
@@ -132,10 +132,10 @@ public class PostServiceImpl implements PostService {
 
         post.addLike(memberId);
 
-        PostLikeCount likeCount = postLikeCountRepository.findById(postId)
+        postLikeCountRepository.findById(postId)
                 .orElseGet(() -> new PostLikeCount(postId, 0L));
-        likeCount.increaseLikeCount();
-        postLikeCountRepository.save(likeCount);
+
+        postLikeCountRepository.incrementLikeCount(postId);
 
         return true;
     }
@@ -152,10 +152,10 @@ public class PostServiceImpl implements PostService {
 
         post.removeLike(memberId);
 
-        PostLikeCount likeCount = postLikeCountRepository.findById(postId)
+        postLikeCountRepository.findById(postId)
                 .orElseGet(() -> new PostLikeCount(postId, 0L));
-        likeCount.decreaseLikeCount();
-        postLikeCountRepository.save(likeCount);
+
+        postLikeCountRepository.decrementLikeCount(postId);
 
         return true;
     }


### PR DESCRIPTION
⭐️ Issue Number
#18

🚩 Summary
여러 사용자가 동시에 '좋아요'를 요청할 때, Race Condition으로 인해 카운트가 누락되는 문제를 해결했습니다.

데이터베이스의 원자적 연산(Atomic Operation)을 활용하여 데이터 정합성을 보장하도록 수정했습니다.

🛠️ Technical Concerns
Read-Modify-Write 패턴으로 인한 Race Condition
문제점: 기존 코드는 PostLikeCount 엔티티를 DB에서 조회(SELECT)하고, 서비스 로직에서 1을 더한 후, 다시 DB에 저장(UPDATE)하는 구조였습니다. 이로 인해 여러 스레드가 거의 동시에 같은 카운트 값을 읽고 각자 덮어쓰면서, 먼저 실행된 다른 스레드의 업데이트가 유실되는 문제가 있었습니다.

해결책: PostLikeCountRepository에 @Modifying 어노테이션과 JPQL을 사용하여, UPDATE PostLikeCount SET likeCount = likeCount + 1 ... 쿼리를 직접 실행하는 incrementLikeCount 메서드를 추가했습니다. 이 변경을 통해 '조회 후 수정' 과정을 하나의 원자적(Atomic) 데이터베이스 트랜잭션으로 만들어 동시성 문제를 해결했습니다.

🙂 To Reviewer
혹시 더 좋은 접근 방식이나 우려되는 부분이 있다면 편하게 의견 남겨주세요