### PR TITLE
Fix: OAuth 2.0 무한 리디렉션 수정

### DIFF
--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/command/AuthMemberCommandAdapter.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/command/AuthMemberCommandAdapter.java
@@ -19,9 +19,9 @@ public class AuthMemberCommandAdapter implements AuthMemberCommandPort {
         Member member = memberRepository.save(Member.builder()
                 .authProvider(command.getAuthProvider())
                 .nickname(command.getNickname())
-                .email(command.getEmail())
+                .providerId(command.getProviderId())
                 .profileImageUrl(command.getProfileImageUrl())
                 .build());
-        return new MemberQueryDto(member.getId(), member.getUuid(), member.getEmail());
+        return new MemberQueryDto(member.getId(), member.getUuid(), member.getProviderId());
     }
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/SecurityConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/SecurityConfig.java
@@ -39,23 +39,24 @@ public class SecurityConfig {
         return http
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
+                .formLogin(formLogin -> formLogin.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(httpRequest -> httpRequest
                         .requestMatchers(
-                                "/api/v1/auth"
-                        )
+                                "/api/v1/auth",
+                                "/social-login",
+                                "/social-login.html")
                         .permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
-                                "/api/v1/posts"
-                        )
+                                "/api/v1/posts",
+                                "/api/v1/posts/*/like")
                         .permitAll()
                         .requestMatchers(
-                                "/api/v1/posts/{postId}/like",
-                                "/api/v1/posts/liked"
-                        )
+                                "/api/v1/posts/*/like",
+                                "/api/v1/posts/liked")
                         .authenticated()
                         .anyRequest()
                         .authenticated())

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebConfig.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/config/WebConfig.java
@@ -10,7 +10,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000", "http://k12e205.p.ssafy.io") // 프론트 주소
+                .allowedOrigins(
+                        "http://localhost",
+                        "http://localhost:3000",
+                        "http://localhost:8081",
+                        "http://k12e205.p.ssafy.io") // 프론트 주소
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/dto/MemberCommandDto.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/dto/MemberCommandDto.java
@@ -9,6 +9,6 @@ public class MemberCommandDto {
 
     private String authProvider;
     private String nickname;
-    private String email;
+    private String providerId;
     private String profileImageUrl;
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/dto/MemberQueryDto.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/dto/MemberQueryDto.java
@@ -9,5 +9,5 @@ public class MemberQueryDto {
 
     private Long id;
     private String uuid;
-    private String email;
+    private String providerId;
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/oauth2/CustomOAuth2UserService.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/oauth2/CustomOAuth2UserService.java
@@ -41,26 +41,32 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String authProvider = userRequest.getClientRegistration().getClientName();
-        String nickname, email, profileImageUrl;
+        String id, nickname, profileImageUrl;
         switch (authProvider) {
             case "Kakao":
+                id = oAuth2User.getAttributes().get("id").toString();
                 Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
                 Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
                 nickname = (String) profile.get("nickname");
-                email = (String) kakaoAccount.get("email");
                 profileImageUrl = (String) profile.get("profile_image_url");
+                break;
+            case "Naver":
+                Map<String, Object> response = (Map<String, Object>) oAuth2User.getAttributes().get("response");
+                id = response.get("id").toString();
+                nickname = (String) response.get("name");
+                profileImageUrl = (String) response.get("profile_image");
                 break;
             default:
                 throw new UnsupportedOAuth2ProviderException("지원하지 않는 OAuth2 제공자입니다.");
         }
-        MemberQueryDto member = authMemberQueryPort.findByEmailAndAuthProvider(email, authProvider).orElseGet(() -> {
+        MemberQueryDto member = authMemberQueryPort.findByIdAndAuthProvider(id, authProvider).orElseGet(() -> {
             // 새 멤버 저장
-            MemberQueryDto newMember = authMemberCommandPort.save(new MemberCommandDto(authProvider, nickname, email, profileImageUrl));
+            MemberQueryDto newMember = authMemberCommandPort.save(new MemberCommandDto(authProvider, nickname, id, profileImageUrl));
 
             // 이벤트 발행
             long randomNumber = (long) (Math.random() * Long.MAX_VALUE);
             eventPublisher.publishEvent(new MemberCreatedEvent(newMember.getId(),
-                    randomNumber + newMember.getEmail()));
+                    randomNumber + "_" +  newMember.getProviderId() + "@example.com"));
 
             return newMember;
         });

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/port/AuthMemberQueryPort.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/auth/port/AuthMemberQueryPort.java
@@ -8,5 +8,5 @@ public interface AuthMemberQueryPort {
 
     Optional<MemberQueryDto> findById(Long id);
 
-    Optional<MemberQueryDto> findByEmailAndAuthProvider(String email, String authProvider);
+    Optional<MemberQueryDto> findByIdAndAuthProvider(String id, String authProvider);
 }

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/member/domain/model/Member.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/member/domain/model/Member.java
@@ -26,7 +26,7 @@ public class Member extends TimestampedEntity {
     private String userKey;
 
     @NotNull
-    private String email;
+    private String providerId;
 
     private String birth;
 

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/member/presentation/dto/response/MemberResponseDto.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/domain/member/presentation/dto/response/MemberResponseDto.java
@@ -10,7 +10,7 @@ public class MemberResponseDto {
     private Long id;
     private String uuid;
     private String userKey;
-    private String email;
+    private String providerId;
     private String birth;
     private Gender gender;
     private String address;
@@ -23,7 +23,7 @@ public class MemberResponseDto {
         dto.id = member.getId();
         dto.uuid = member.getUuid();
         dto.userKey = member.getUserKey();
-        dto.email = member.getEmail();
+        dto.providerId = member.getProviderId();
         dto.birth = member.getBirth();
         dto.gender = member.getGender();
         dto.address = member.getAddress();

--- a/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/query/AuthMemberQueryAdapter.java
+++ b/backend/nextdoor/src/main/java/com/nextdoor/nextdoor/query/AuthMemberQueryAdapter.java
@@ -24,7 +24,7 @@ public class AuthMemberQueryAdapter implements AuthMemberQueryPort {
                         MemberQueryDto.class,
                         qMember.id,
                         qMember.uuid,
-                        qMember.email
+                        qMember.providerId
                 ))
                 .from(qMember)
                 .where(qMember.id.eq(id))
@@ -32,15 +32,15 @@ public class AuthMemberQueryAdapter implements AuthMemberQueryPort {
     }
 
     @Override
-    public Optional<MemberQueryDto> findByEmailAndAuthProvider(String email, String authProvider) {
+    public Optional<MemberQueryDto> findByIdAndAuthProvider(String id, String authProvider) {
         return Optional.ofNullable(jpaQueryFactory.select(Projections.constructor(
                         MemberQueryDto.class,
                         qMember.id,
                         qMember.uuid,
-                        qMember.email
+                        qMember.providerId
                 ))
                 .from(qMember)
-                .where(qMember.email.eq(email).and(qMember.authProvider.eq(authProvider)))
+                .where(qMember.providerId.eq(id).and(qMember.authProvider.eq(authProvider)))
                 .fetchOne());
     }
 }

--- a/backend/nextdoor/src/main/resources/application-dev.yml
+++ b/backend/nextdoor/src/main/resources/application-dev.yml
@@ -55,11 +55,33 @@ spring:
   security:
     oauth2:
       client:
+        registration:
+          kakao:
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/api/v1/auth/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - profile_image
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+          naver:
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/api/v1/auth/oauth2/code/{registrationId}"
+            scope:
+              - name
+              - email
+            client-name: Naver
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
   ai:
     vertex:


### PR DESCRIPTION
## ⭐️ Issue Number

- #29 

## 🚩 Summary

- OAuth 2.0 흐름에서 인증 후 인가 과정에서 무한 리디렉션 발생하는 부분 수정

- 카카오 사용자 정보 중 이메일을 식별자(id)로 대체

- 인가를 위해 인증을 필요로 하는 경로 수정

- CORS 허용 origin 수정

- 네이버 로그인 추가

## 🛠️ Technical Concerns

### 문제 상황

무한 리디렉션이 발생할 때는 errorCode cannot be null이라는 로그가 나왔습니다.

### 원인

의심되는 원인은 아래 2가지였습니다.

1. 카카오 개발자 계정 및 어플리케이션이 차단됨

2. 인가 성공 후 클라이언트를 리디렉션 시키는 경로 /social-login이 정상적으로 등록되지 않음 

### 해결 방안

1번 해결을 위해 우선 카카오 데브톡에 문의해서 차단을 해제했습니다.

2번 해결을 위해 디버깅을 했더니, 로컬에서 서버 테스트 시 social-login.html을 포워딩하는데, 이게 매칭되지 않았습니다. 따라서 설정에 /social-login.html을 추가해서 해결했습니다.

## 🙂 To Reviewer

더 이상 핀테크 API를 사용할 수 없어 회원가입 후 핀테크 사용자 생성 시 예외가 발생하는 점 참고 바랍니다.

더 이상 OAuth 2.0 리소스 서버에서 이메일을 가져올 수 없기 때문에 핀테크 사용자 생성 시 임의로 이메일을 생성하도록 만들었습니다.

## 📋 To Do